### PR TITLE
Fix GitHub Actions Node 24 compatibility and correct package.json syntax

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,25 +7,25 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # If your repository depends on submodule, please see: https://github.com/actions/checkout
           submodules: recursive
       - name: Checkout notes
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: wliafe/notes
           ref: main
           path: source/_posts
       - name: Use Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           # Examples: 20, 18.19, >=16.20.2, lts/Iron, lts/Hydrogen, *, latest, current, node
           # Ref: https://github.com/actions/setup-node#supported-version-syntax
           node-version: "22"
       - name: Cache NPM dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: ${{ runner.OS }}-npm-cache
@@ -36,7 +36,7 @@ jobs:
       - name: Build
         run: npm run build
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./public
   deploy:
@@ -51,4 +51,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "hexo-renderer-stylus": "^3.0.1",
     "hexo-server": "^3.0.0",
     "hexo-theme-landscape": "^1.0.0",
-    "hexo-word-counter": "^0.2.2"
-    "hexo-theme-next": "^8.27.0",
+    "hexo-word-counter": "^0.2.2",
+    "hexo-theme-next": "^8.27.0"
   }
 }


### PR DESCRIPTION
### Motivation
- 解决 CI 报错 "Node.js 20 actions are deprecated" 的兼容性问题，确保使用支持 Node.js 24 的 Actions 主版本以避免未来运行时移除导致的中断。 
- 修复 `package.json` 的 JSON 语法错误以避免 CI 在 `npm install` 阶段因解析失败直接退出。 

### Description
- 在 `.github/workflows/pages.yml` 中将 `actions/checkout@v4` 升级为 `actions/checkout@v6`、`actions/setup-node@v4` 升级为 `actions/setup-node@v6`、`actions/cache@v4` 升级为 `actions/cache@v5`、`actions/upload-pages-artifact@v3` 升级为 `actions/upload-pages-artifact@v5`、以及 `actions/deploy-pages@v4` 升级为 `actions/deploy-pages@v5`。 
- 保持工作流中的 `node-version: "22"` 配置不变，但使用上述新版 Actions 来获得对 Node.js 24 的兼容支持。 
- 修复 `package.json` 依赖区的逗号问题：在 `hexo-word-counter` 后补上缺失的逗号并移除 `hexo-theme-next` 后的尾随逗号以生成合法 JSON。 

### Testing
- 执行 `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pages.yml")'`，工作流 YAML 解析成功。 
- 执行 `python -m json.tool package.json`，`package.json` 格式验证通过。 
- 执行 `git diff --check`，未发现空白/格式错误。 
- 尝试 `npm install` 与 `npm run build` 时网络/registry 返回 `403` 导致依赖无法安装，因而构建未能在当前环境完成。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bf5601b348333974b69fe6a8e5bb1)